### PR TITLE
Fix theme PHP warnings and sitemap error

### DIFF
--- a/inc/seo.php
+++ b/inc/seo.php
@@ -509,15 +509,15 @@ add_filter('pre_get_document_title', 'mohtawa_custom_document_title');
  * إضافة Sitemap XML للمتاجر
  */
 function mohtawa_add_stores_to_sitemap($provider, $name) {
-    if ('posts' !== $name) {
+    if ('posts' !== $name || !method_exists($provider, 'add_sitemap')) {
         return $provider;
     }
-    
+
     $provider->add_sitemap('stores', array(
-        'loc' => home_url('/wp-sitemap-stores.xml'),
-        'lastmod' => get_lastpostmodified('gmt', 'store')
+        'loc'     => home_url('/wp-sitemap-stores.xml'),
+        'lastmod' => get_lastpostmodified('gmt', 'store'),
     ));
-    
+
     return $provider;
 }
 add_filter('wp_sitemaps_add_provider', 'mohtawa_add_stores_to_sitemap', 10, 2);

--- a/parts/filter-sidebar.php
+++ b/parts/filter-sidebar.php
@@ -16,9 +16,14 @@
             $categories = get_terms( array(
                 'taxonomy'   => 'store_category',
                 'hide_empty' => false,
+                'fields'     => 'all',
             ) );
             foreach ( $categories as $category ) {
-                echo '<li><label><input type="checkbox" class="filter-checkbox" data-filter="category" value="' . esc_attr( $category->slug ) . '"> ' . esc_html( $category->name ) . '</label></li>';
+                $term = is_object( $category ) ? $category : get_term( $category, 'store_category' );
+                if ( ! $term || is_wp_error( $term ) ) {
+                    continue;
+                }
+                echo '<li><label><input type="checkbox" class="filter-checkbox" data-filter="category" value="' . esc_attr( $term->slug ) . '"> ' . esc_html( $term->name ) . '</label></li>';
             }
             ?>
         </ul>


### PR DESCRIPTION
## Summary
- avoid calling nonexistent `add_sitemap` by checking method
- handle `get_terms` results robustly in filter sidebar

## Testing
- `php -l inc/seo.php`
- `php -l parts/filter-sidebar.php`


------
https://chatgpt.com/codex/tasks/task_e_68769b9e8d8483238e0900937cf1a916